### PR TITLE
Remove "relative" imports

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -18,7 +18,7 @@ package cmd
 import (
 	"fmt"
 
-	"pg-cli/db"
+	"github.com/kohrVid/pg-cli/db"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -18,7 +18,7 @@ package cmd
 import (
 	"fmt"
 
-	"pg-cli/db"
+	"github.com/kohrVid/pg-cli/db"
 
 	_ "github.com/lib/pq"
 	"github.com/spf13/cobra"

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -18,7 +18,7 @@ package cmd
 import (
 	"fmt"
 
-	"pg-cli/db"
+	"github.com/kohrVid/pg-cli/db"
 
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"

--- a/cmd/drop.go
+++ b/cmd/drop.go
@@ -18,7 +18,7 @@ package cmd
 import (
 	"fmt"
 
-	"pg-cli/db"
+	"github.com/kohrVid/pg-cli/db"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/cmd/migrate_version.go
+++ b/cmd/migrate_version.go
@@ -18,7 +18,7 @@ package cmd
 import (
 	"fmt"
 
-	"pg-cli/db"
+	"github.com/kohrVid/pg-cli/db"
 
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"

--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -18,7 +18,7 @@ package cmd
 import (
 	"fmt"
 
-	"pg-cli/db"
+	"github.com/kohrVid/pg-cli/db"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/cmd/step.go
+++ b/cmd/step.go
@@ -18,7 +18,7 @@ package cmd
 import (
 	"fmt"
 
-	"pg-cli/db"
+	"github.com/kohrVid/pg-cli/db"
 
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -18,7 +18,7 @@ package cmd
 import (
 	"fmt"
 
-	"pg-cli/db"
+	"github.com/kohrVid/pg-cli/db"
 
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module pg-cli
+module github.com/kohrVid/pg-cli
 
 go 1.17
 
@@ -45,4 +45,11 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-replace github.com/kohrVid/pg-cli v0.1.1 => pg-cli v0.1.1
+retract (
+	// Mistake made in release DO NOT USE
+	v0.1.3
+	// Mistake made in release DO NOT USE
+	v0.1.2
+	// Mistake made in release DO NOT USE
+	v0.1.1
+)

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package main
 
-import "pg-cli/cmd"
+import "github.com/kohrVid/pg-cli/cmd"
 
 func main() {
 	cmd.Execute()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -182,4 +182,3 @@ gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 ## explicit
 gopkg.in/yaml.v3
-# github.com/kohrVid/pg-cli v0.1.1 => pg-cli v0.1.1


### PR DESCRIPTION
This PR reverts changes made in an earlier commit that attempted to use relative imports within the module in a way that isn't supported by golang. The PR also attempts to retract previous releases published in error.